### PR TITLE
Deprecate some configuration options

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-AUTHORS for GluCat 0.10.0 with PyClical
+AUTHORS for GluCat 0.10.1 with PyClical
 ======================================
 
 Paul C. Leopardi <leopardi@users.sourceforge.net>

--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,4 @@
-INSTALL for GluCat 0.10.0 with PyClical
+INSTALL for GluCat 0.10.1 with PyClical
 ========================================
 
 Prerequisites: Before You Begin
@@ -30,13 +30,13 @@ You can install GluCat in one of two ways:
 To install the first way, from (e.g.) GitHub, run the following commands on a
 Linux machine or equivalent Posix environment connected to the Internet:
 
-> git clone git@github.com:penguian/glucat.git glucat-0.10.0
-> cd glucat-0.10.0
+> git clone git@github.com:penguian/glucat.git glucat-0.10.1
+> cd glucat-0.10.1
 > make -f admin/Makefile.common cvs
 
-This results in a directory structure that includes glucat-0.10.0/configure,
+This results in a directory structure that includes glucat-0.10.1/configure,
 allowing you to make and install GluCat in the same way as if you had downloaded
-and unzipped the tarball glucat-0.10.0.tar.gz.
+and unzipped the tarball glucat-0.10.1.tar.gz.
 
 
 Directory Structure
@@ -44,11 +44,11 @@ Directory Structure
 
 Once you have downloaded, unzipped and untarred the source code, or followed
 the instructions above to install from Git clone, you should have a directory,
-glucat-0.10.0. Under this directory you should see a number
+glucat-0.10.1. Under this directory you should see a number
 of subdirectories, including ./admin, ./doc, ./glucat, ./gfft_test, ./products,
 ./pyclical, ./squaring, ./test, ./test_runtime, ./testxx, and ./transforms.
 
-The following instructions are meant to be used with glucat-0.10.0 as the
+The following instructions are meant to be used with glucat-0.10.1 as the
 current directory.
 
 
@@ -146,7 +146,7 @@ subdirectories.
 
 As briefly described above, the simplest way to install this package is:
 
- 1. "cd" to the glucat-0.10.0 directory containing the source code and type
+ 1. "cd" to the glucat-0.10.1 directory containing the source code and type
     "./configure" to configure GluCat with PyClical for your system.
     If you are using "csh" on an old version of System V, you might need to type
     "sh ./configure" instead to prevent "csh" from trying to execute
@@ -288,6 +288,11 @@ PyClical.cpp file. See details in "To Build" below.
 
   --enable-check-isnan    check for NaN values at various places in the code [default=yes]
 
+[DEPRECATED: In practice, this type of checking has not slowed execution speed
+by much. Also, the code now also checks for Inf in various places and it is
+not clear how this option should be changed to cope with check for Inf. In
+future releases the checks for Inf and NaN will always be performed.]
+
 This option determines whether the GluCat library code uses the potentially
 expensive isnan() member function to check for NaN values within the
 matrix_multi<> implementations of operator*() and operator/().
@@ -332,6 +337,13 @@ This option defines the installation directory for the PyClical demos.
                           (libcxx|libstdcxx)
                           [default=libstdcxx]
 
+[DEPRECATED: This option will be removed in future releases. This option is
+currently applied only to Clang++ and only when the option libcxx is chosen.
+The default for recent Clang++ versions is to use libc++ rather than libstdc++.
+In other words, contrary to the INSTALL documentation, this option has no
+effect. It is not clear at this stage what value would be added by allowing
+Clang++ to use libstdc++.]
+
 This option controls which C++ standard library is to be used. ARG can be
 "libcxx" or "libstdcxx". The default is "libstdcxx".
 
@@ -352,6 +364,11 @@ For further details, see http://libcxx.llvm.org/docs/
   --with-map[=ARG]        type of map to use
                           (map|stdunordered)
                           [default=stdunordered]
+
+[DEPRECATED: This option will be removed in future releases. In practice, the
+hash function used with framed_multi<> has worked reasonably well, and has been
+asymptotically faster than just using std::map. In future releases std::map<>
+will only be used in cases where ordering is needed, such as printing.]
 
 This option controls preprocessor symbols of the form _GLUCAT_USE_*_MAP that
 determine the type of map used by glucat::framed_multi<>. ARG can be "map"
@@ -386,6 +403,10 @@ exist.
   --with-pool-alloc       use Boost Pool allocator
                           [default=no]
 
+[DEPRECATED: This option will be removed in future releases. The use of the
+Boost pool allocator only affects std::map<>, and the code performs adequately
+without it. In future releases the Boost pool allocator will no longer be used.]
+
 This option determines whether the GluCat library code uses the Boost pool
 allocator with objects of type std::map<>.
 
@@ -414,6 +435,12 @@ https://svn.boost.org/trac/boost/ticket/7335
 
 
   --with-dense-mat        uses dense matrices [default=yes]
+
+[DEPRECATED: This option will be removed in future releases. While the code
+works with sparse matrices, in practice the uBLAS sparse implementation is too
+slow for general arithmetic operations, while multi-gigabyte memory spaces are
+now common. In future releases sparse matrices will only be used in cases where
+sparsity is helpful, such as the basis element cache.]
 
 This option controls the preprocessor symbol _GLUCAT_USE_DENSE_MATRICES that
 determines the type of matrix used by glucat::matrix_multi<>.
@@ -457,6 +484,10 @@ You will also need to ensure that the include path used by the compiler sees
 
   --with-random[=ARG]     type of random number generator to use
                           (std|gsl) [default=std]
+
+[DEPRECATED: This option will be removed in future releases. The C++11 standard
+random number generators essentially supercede the GSL random number generators.
+In future releases the standard random number generators will always be used.]
 
 This option controls preprocessor symbols of the form _GLUCAT_USE_*_MAP that
 determine which random number generators are used by glucat::random_generator<>
@@ -843,9 +874,9 @@ speeding up the entire testing process.
 
 Rather than running the regression tests in-place and copying the output
 directly into ./test_runtime, the script ./test/test-all-config-options.sh
-produces as many copies of the whole direcory glucat-0.10.0 as there are lines
-in ./test/config-options.txt, naming them glucat-0.10.0.1 to glucat-0.10.0.15,
-in the parent directory of glucat-0.10.0. This allows the effect of each set
+produces as many copies of the whole direcory glucat-0.10.1 as there are lines
+in ./test/config-options.txt, naming them glucat-0.10.1.1 to glucat-0.10.1.15,
+in the parent directory of glucat-0.10.1. This allows the effect of each set
 of configuration options to be directly compared, and also ensures that any
 side-effect of a configuration does not affect the test results of another
 configuration.
@@ -857,9 +888,9 @@ line 8 of ./test/config-options.txt
 map-map-gsl:                 --with-map=map --with-random=gsl
 
 causes ./test/diff-all-config-outputs.sh to use diff to compare
-glucat-0.10.0.8/test_runtime/test.configure.map-map-gsl.out to
-glucat-0.10.0/test_runtime/test.configure.map-map-gsl.out, and compare
-glucat-0.10.0.8/pyclical/test.out to glucat-0.10.0/pyclical/test.out.
+glucat-0.10.1.8/test_runtime/test.configure.map-map-gsl.out to
+glucat-0.10.1/test_runtime/test.configure.map-map-gsl.out, and compare
+glucat-0.10.1.8/pyclical/test.out to glucat-0.10.1/pyclical/test.out.
 
 Each comparison should only produce a line containing the line number of
 the configuration being compared: 1 to 15.
@@ -987,7 +1018,7 @@ to use sudo, login as root, or su to root before you run make install.
  List of Successful Builds
  =========================
 
- GluCat 0.10.0 with PyClical has so far been built and tested using:
+ GluCat 0.10.1 with PyClical has so far been built and tested using:
 
  1) Pensieri:
     4 core Intel(R) Core(TM) i7 CPU 870  @ 2.93GHz with
@@ -1275,7 +1306,7 @@ Notes on software versions
 
 
     The following bugs and workarounds apply to earlier versions of GluCat,
-    and may still be applicable to GluCat 0.10.0, but have not been checked
+    and may still be applicable to GluCat 0.10.1, but have not been checked
     for this version.
 
 

--- a/INSTALL
+++ b/INSTALL
@@ -1083,19 +1083,19 @@ to use sudo, login as root, or su to root before you run make install.
  3) Pensieri (VirtualBox):
     Virtual 1 core Intel(R) Core(TM) i7 CPU 870 @ 2.93GHz with
 
-    Linux 5.15.7-1-default #1 SMP (b92986a)
-    openSUSE Tumbleweed Snapshot 20211215
-    g++ (SUSE Linux) 11.2.1 20211124
-    Boost 1.77.0
+    Linux 5.16.8-1-default #1 SMP 2022
+    openSUSE Tumbleweed Snapshot TBD 20211215
+    g++ (SUSE Linux) 11.2.1 20220103
+    Boost 1.78.0
     Boost Numeric Bindings
-    GSL 2.6-6.3
-    QD 2.3.22-1.12
+    GSL 2.6-6.4
+    QD 2.3.22-1.13
     Python 3.8.12
     Numpy 1.21.4
-    Matplotlib 3.4.3
+    Matplotlib 3.5.1
     Mayavi2 4.7.4
-    VTK 9.1.0
-    Doxygen 1.9.2
+    VTK 9.1.0-1.8
+    Doxygen 1.9.2-1.2
     pdfTeX 3.141592653-2.6-1.40.22 (TeX Live 2021/TeX Live for SUSE Linux)
 
     ./test/fast-test-all-config-options.sh
@@ -1105,10 +1105,10 @@ to use sudo, login as root, or su to root before you run make install.
  4) NCI Gadi:
     48 core Intel(R) Xeon(R) Platinum 8274 CPU @ 3.20GHz with
 
-    Linux  4.18.0-305.19.1.el8.nci.x86_64 SMP x86_64
+    Linux  4.18.0-348.2.1.el8.nci.x86_64 SMP x86_64
     Rocky Linux release 8.4 (Green Obsidian)
-    1) icpc version 2021.4.0
-    2) icpx version 2021.4.0
+    1) icpc version 2021.5.0
+    2) icpx version 2021.5.0
     Boost 1.77.0
     Boost Numeric Bindings
     Cython 0.29.24

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-README for GluCat 0.10.0 with PyClical
+README for GluCat 0.10.1 with PyClical
 =====================================
 
 GluCat is a library of C++ template classes for calculations with the universal

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -32,7 +32,7 @@ dnl    Boston, MA 02111-1307, USA.
 
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([glucat],[0.10.0])
+AC_INIT([glucat],[0.10.1])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/m4_ax_cxx_compile_stdcxx.m4])
 m4_include([m4/m4_ax_blas.m4])
@@ -44,9 +44,16 @@ AC_DEFUN([GLUCAT_TOUPPER],[$(echo $1 | tr ["[a-z]" "[A-Z]"])])
 
 dnl checks specific to GluCat
 
+glucat_deprecated_warning="is deprecated and will be removed in future releases. See INSTALL for details."
+
 AC_DEFUN([GLUCAT_MSG_WARN_DEPRECATED],
 [
-  AC_MSG_WARN([The option $1=$2 is deprecated and will be removed in future versions.])
+  AC_MSG_WARN([The option $1 $glucat_deprecated_warning])
+])
+
+AC_DEFUN([GLUCAT_MSG_WARN_DEPRECATED_VAL],
+[
+  AC_MSG_WARN([The option $1=$2 $glucat_deprecated_warning])
 ])
 
 AC_DEFUN([GLUCAT_CHECK_COMPILERS],
@@ -58,6 +65,7 @@ AC_DEFUN([GLUCAT_CHECK_COMPILERS],
   all_libraries=""
 
   dnl process the command line arguments
+
 
   AC_ARG_ENABLE([debug],      [[  --enable-debug[=ARG]    enable debug symbols (yes|no|full) [default=no]]],
   [
@@ -118,9 +126,11 @@ AC_DEFUN([GLUCAT_CHECK_COMPILERS],
     [glucat_use_pyclical="$enableval"],
     [glucat_use_pyclical="yes"])
 
-  AC_ARG_ENABLE([check-isnan],[[  --enable-check-isnan    check for NaN values at various places in the code [default=yes]]],
-    [glucat_check_isnan="$enableval"],
-    [glucat_check_isnan="yes"])
+  AC_ARG_ENABLE([check-isnan],[[  --enable-check-isnan    check for NaN values at various places in the code [DEPRECATED, default=yes]]],
+  [
+    GLUCAT_MSG_WARN_DEPRECATED([--enable-check-isnan])
+    glucat_check_isnan="$enableval"
+  ],[glucat_check_isnan="yes"])
 
   AC_ARG_WITH([demo-dir],
     AS_HELP_STRING([--with-demo-dir=DIR],                [define the installation directory for the PyClical demos [default=$DATAROOTDIR/pyclical/demos]]),,
@@ -128,8 +138,9 @@ AC_DEFUN([GLUCAT_CHECK_COMPILERS],
   demodir="$with_demo_dir"
   AC_SUBST([demodir])
 
-  AC_ARG_WITH([stdlib],       [[  --with-stdlib[=ARG]     C++ standard library to use (libcxx|libstdcxx) [default=libstdcxx]]],
+  AC_ARG_WITH([stdlib],       [[  --with-stdlib[=ARG]     C++ standard library to use (libcxx|libstdcxx) [DEPRECATED, default=libstdcxx]]],
   [
+    GLUCAT_MSG_WARN_DEPRECATED_VAL([--with-stdlib],[$withval])
     case "$withval" in
       libcxx)
         glucat_use_stdlib="libcxx"
@@ -143,8 +154,9 @@ AC_DEFUN([GLUCAT_CHECK_COMPILERS],
     esac
   ],[glucat_use_stdlib="libstdcxx"])
 
-  AC_ARG_WITH([map],          [[  --with-map[=ARG]        type of map to use (map|stdunordered) [default=stdunordered]]],
+  AC_ARG_WITH([map],          [[  --with-map[=ARG]        type of map to use (map|stdunordered) [DEPRECATED, default=stdunordered]]],
   [
+    GLUCAT_MSG_WARN_DEPRECATED_VAL([--with-map],[$withval])
     case "$withval" in
       map)
         glucat_use_map="map"
@@ -158,16 +170,19 @@ AC_DEFUN([GLUCAT_CHECK_COMPILERS],
     esac
   ],[glucat_use_map="stdunordered"])
 
-  AC_ARG_WITH([dense-mat],    [[  --with-dense-mat        use dense matrices [default=yes]]],
-    [glucat_use_dense_mat="$withval"],
-    [glucat_use_dense_mat="yes"])
+  AC_ARG_WITH([dense-mat],    [[  --with-dense-mat        use dense matrices [DEPRECATED, default=yes]]],
+  [
+    GLUCAT_MSG_WARN_DEPRECATED([--with-dense-mat])
+    glucat_use_dense_mat="$withval"
+  ],[glucat_use_dense_mat="yes"])
 
   AC_ARG_WITH([qd],           [[  --with-qd               use dd_real and qd_real [default=no]]],
     [glucat_use_qd="$withval"],
     [glucat_use_qd="no"])
 
-  AC_ARG_WITH([random],       [[  --with-random[=ARG]     type of random number generator to use (std|gsl) [default=std]]],
+  AC_ARG_WITH([random],       [[  --with-random[=ARG]     type of random number generator to use (std|gsl) [DEPRECATED, default=std]]],
   [
+    GLUCAT_MSG_WARN_DEPRECATED_VAL([--with-random],[$withval])
     case "$withval" in
       std)
         glucat_use_random="std"
@@ -196,9 +211,11 @@ AC_DEFUN([GLUCAT_CHECK_COMPILERS],
     esac
   ],[glucat_use_eigenvalues="no"])
 
-  AC_ARG_WITH([pool-alloc],   [[  --with-pool-alloc       use Boost Pool allocator [default=no]]],
-    [glucat_use_boost_pool_alloc="$withval"],
-    [glucat_use_boost_pool_alloc="no"])
+  AC_ARG_WITH([pool-alloc],   [[  --with-pool-alloc       use Boost Pool allocator [DEPRECATED, default=no]]],
+  [
+    GLUCAT_MSG_WARN_DEPRECATED([--with-pool-alloc])
+    glucat_use_boost_pool_alloc="$withval"
+  ],[glucat_use_boost_pool_alloc="no"])
 
   dnl Check for a C++ compiler
   AC_LANG([C]++)

--- a/glucat.lsm
+++ b/glucat.lsm
@@ -1,7 +1,7 @@
 Begin3
 Title:          GluCat
-Version:        0.10.0
-Entered-date:   2022-02-08
+Version:        0.10.1
+Entered-date:   2022-02-14
 Description:    Generic library of universal Clifford algebra templates
 Keywords:       Clifford algebra, geometric algebra, template library
 Author:         Paul C. Leopardi <leopardi@users.sourceforge.net>

--- a/pyclical/test.out
+++ b/pyclical/test.out
@@ -1,3 +1,3 @@
->>> 0.10.0
+>>> 0.10.1
 >>> TestResults(failed=0, attempted=629)
 >>> 


### PR DESCRIPTION
Closes Issue #40
The main effect of this change is to add warning messages to `./configure` for deprecated configuration options. It does not change any of the generated binaries. Some test results have been updated to use the latest available environment.

 